### PR TITLE
Fix iOS push notifications

### DIFF
--- a/app/App_Resources/iOS/Info.plist
+++ b/app/App_Resources/iOS/Info.plist
@@ -52,7 +52,5 @@
 	<array>
 	<string>remote-notification</string>
 	</array>
-	<key>FirebaseAppDelegateProxyEnabled</key>
-    <false/>
 </dict>
 </plist>

--- a/app/App_Resources/iOS/build.xcconfig
+++ b/app/App_Resources/iOS/build.xcconfig
@@ -1,7 +1,9 @@
 // You can add custom settings here
 // for example you can uncomment the following line to force distribution code signing
-// CODE_SIGN_IDENTITY = iPhone Distribution 
+// CODE_SIGN_IDENTITY = iPhone Distribution
 // To build for device with Xcode 8 you need to specify your development team. More info: https://developer.apple.com/library/prerelease/content/releasenotes/DeveloperTools/RN-Xcode/Introduction.html
 // DEVELOPMENT_TEAM = YOUR_TEAM_ID;
 ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+
+CODE_SIGN_ENTITLEMENTS = firebasepushnotificationstrial/firebasepushnotificationstrial.entitlements

--- a/app/App_Resources/iOS/firebasepushnotificationstrial.entitlements
+++ b/app/App_Resources/iOS/firebasepushnotificationstrial.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+</dict>
+</plist>

--- a/package.json
+++ b/package.json
@@ -6,17 +6,17 @@
   "nativescript": {
     "id": "com.sminq.places",
     "tns-ios": {
-      "version": "3.3.0"
+      "version": "3.4.1"
     }
   },
   "scripts": {
     "lint": "eslint \"app/**/*.js\""
   },
   "dependencies": {
-    "nativescript-plugin-firebase": "^5.1.1",
+    "nativescript-plugin-firebase": "^5.1.7",
     "nativescript-social-share": "^1.5.0",
     "nativescript-theme-core": "1.0.4",
-    "tns-core-modules": "3.3.0"
+    "tns-core-modules": "~3.4.0"
   },
   "devDependencies": {
     "eslint": "4.9.0",


### PR DESCRIPTION
Fixes #1

In addition to removing that bit in #1 from `Info.plist`, also add these entitlements to enable background push notifications in your Xcode project.